### PR TITLE
Only reset timer, not prev_state

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ optional arguments:
                         Interval for automatically saving settings in seconds.
                         Default: 60
   --sacn                Enable sACN / E1.31 support. Default: False
-  --no_timer_reset      Do not reset the animation timer and state when
-                        patterns are changed. Default: False
+  --no_timer_reset      Do not reset the animation timer when patterns are
+                        changed. Default: False
 ```
 
 ### Built-In Animation Patterns

--- a/ledcontrol/animationcontroller.py
+++ b/ledcontrol/animationcontroller.py
@@ -223,7 +223,6 @@ class AnimationController:
     def _check_reset_animation_state(self):
         if not self._no_timer_reset:
             self.reset_timer()
-            self.reset_prev_states()
 
     def set_param(self, key, value):
         'Set an animation parameter'


### PR DESCRIPTION
Refinement on your (fast!) PR to my issue #19  this week. As I noted on the closed Issue:

- `prev_state` and cycle count behavior are more accurately scoped to patterns, rather than the global execution. 
- The most flexibility for the user is when `prev_state` consistently holds the previous state, and `t` is reset at change of  pattern/compile.  If the  user wants prev_state zeroed out at cycle 1, it's easy enough to do it. If not, it's irrelevant.
- is there ever really a use case for preserving cycle count for the whole execution time?

This PR makes it only reset the cycle count, *not* the prev_state.