### PR TITLE
Add hsv to rgb conversion function in restricted list

### DIFF
--- a/ledcontrol/animationcontroller.py
+++ b/ledcontrol/animationcontroller.py
@@ -148,6 +148,7 @@ class AnimationController:
             'fract': utils.fract,
             'blackbody_to_rgb': driver.blackbody_to_rgb,
             'blackbody_correction_rgb': driver.blackbody_correction_rgb,
+            'hsv_to_rgb': self.hsv_to_rgb,
         }
         restricted_locals = {}
         arg_names = ['t', 'dt', 'x', 'y', 'z', 'prev_state']
@@ -276,6 +277,17 @@ class AnimationController:
         self.palette_table = palette_table
         self.palette_length = len(palette['colors'])
         self.update_needed = True
+
+    def hsv_to_rgb(h, s, v):
+        if s == 0.0: v*=255; return (v, v, v)
+        i = int(h*6.) # XXX assume int() truncates!
+        f = (h*6.)-i; p,q,t = int(255*(v*(1.-s))), int(255*(v*(1.-s*f))), int(255*(v*(1.-s*(1.-f)))); v*=255; i%=6
+        if i == 0: return (v, t, p)
+        if i == 1: return (q, v, p)
+        if i == 2: return (p, v, t)
+        if i == 3: return (p, q, v)
+        if i == 4: return (t, p, v)
+        if i == 5: return (v, p, q)
 
     def get_palette_color(self, t):
         'Get color from current palette corresponding to index between 0 and 1'


### PR DESCRIPTION
So far the only functions that return RGB colors are ones that ignore the palette. This PR adds a function (shamelessly learned from [stackoverflow](https://stackoverflow.com/questions/24852345/hsv-to-rgb-color-conversion)) for converting HSV to RGB.  I don't think the reverse is necessary, since the palette functions return HSV and the whole primary pattern can return RGB without problem.

One thing I'm not sure about though: does `prev_state` always come in HSV? Or if the previous loop returned RGB, will we get RGB on the second loop? If it's the latter case, this PR needs some work to either:

- identify if prev_state is HSV vs RGB, or
- ensure prev_state always comes in as HSV.